### PR TITLE
fix creating refund metadata from event

### DIFF
--- a/examples/p2p-transfers/main.go
+++ b/examples/p2p-transfers/main.go
@@ -85,7 +85,7 @@ func main() {
 			libratypes.Currency(currency),
 			custodialAccountChildVasp.AccountAddress(),
 			amount,
-			txnmetadata.NewGeneralMetadataWithFromToSubaddresses(
+			txnmetadata.NewGeneralMetadataWithFromToSubAddresses(
 				senderCustodialAccountSubAddress,
 				custodialAccountSubAddress,
 			),

--- a/libraclient/libraclienttest/event_builder.go
+++ b/libraclient/libraclienttest/event_builder.go
@@ -1,0 +1,51 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package libraclienttest
+
+import "github.com/libra/libra-client-sdk-go/libraclient"
+
+type eventBuilderPart func(*libraclient.Event)
+type EventBuilder struct {
+	parts []eventBuilderPart
+}
+
+func (b EventBuilder) Build() *libraclient.Event {
+	t := new(libraclient.Event)
+	for _, part := range b.parts {
+		part(t)
+	}
+	return t
+}
+
+func (b EventBuilder) Type(t string) *EventBuilder {
+	return b.append(func(e *libraclient.Event) {
+		e.Data.Type = t
+	})
+}
+
+func (b EventBuilder) SequenceNumber(n uint64) *EventBuilder {
+	return b.append(func(e *libraclient.Event) {
+		e.SequenceNumber = n
+	})
+}
+
+func (b EventBuilder) Receiver(receiver string) *EventBuilder {
+	return b.append(func(e *libraclient.Event) {
+		e.Data.Receiver = receiver
+	})
+}
+
+func (b EventBuilder) Metadata(metadata string) *EventBuilder {
+	return b.append(func(e *libraclient.Event) {
+		e.Data.Metadata = metadata
+	})
+}
+
+func (b *EventBuilder) append(parts ...eventBuilderPart) *EventBuilder {
+	newParts := make([]eventBuilderPart, len(b.parts)+len(parts))
+	copy(newParts, b.parts)
+	copy(newParts[len(b.parts):], parts)
+	b.parts = newParts
+	return b
+}

--- a/libraclient/libraclienttest/transaction_builder.go
+++ b/libraclient/libraclienttest/transaction_builder.go
@@ -1,0 +1,35 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package libraclienttest
+
+import "github.com/libra/libra-client-sdk-go/libraclient"
+
+type transactionBuilderPart func(*libraclient.Transaction)
+type TransactionBuilder struct {
+	parts []transactionBuilderPart
+}
+
+func (b *TransactionBuilder) Build() *libraclient.Transaction {
+	t := new(libraclient.Transaction)
+	for _, part := range b.parts {
+		part(t)
+	}
+	return t
+}
+
+func (b TransactionBuilder) Events(events ...*EventBuilder) *TransactionBuilder {
+	return b.append(func(t *libraclient.Transaction) {
+		for _, event := range events {
+			t.Events = append(t.Events, *event.Build())
+		}
+	})
+}
+
+func (b *TransactionBuilder) append(parts ...transactionBuilderPart) *TransactionBuilder {
+	newParts := make([]transactionBuilderPart, len(b.parts)+len(parts))
+	copy(newParts, b.parts)
+	copy(newParts[len(b.parts):], parts)
+	b.parts = newParts
+	return b
+}

--- a/libratypes/subaddress_test.go
+++ b/libratypes/subaddress_test.go
@@ -15,9 +15,9 @@ func TestGenSubAddress(t *testing.T) {
 	address, err := libratypes.GenSubAddress()
 	assert.NoError(t, err)
 	assert.Len(t, address, 8)
-	// for i := 0; i < 10000; i++ {
-	// 	require.NotEqual(t, address, libratypes.MustGenSubAddress())
-	// }
+	for i := 0; i < 10000; i++ {
+		require.NotEqual(t, address, libratypes.MustGenSubAddress())
+	}
 }
 
 func TestNewSubAddressErrorsForInvalidSubAddress(t *testing.T) {

--- a/txnmetadata/metadata_test.go
+++ b/txnmetadata/metadata_test.go
@@ -7,7 +7,10 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang/lcs"
 	"github.com/libra/libra-client-sdk-go/libraclient"
+	"github.com/libra/libra-client-sdk-go/libraclient/libraclienttest"
+	"github.com/libra/libra-client-sdk-go/librakeys"
 	"github.com/libra/libra-client-sdk-go/libratypes"
 	"github.com/libra/libra-client-sdk-go/txnmetadata"
 	"github.com/stretchr/testify/assert"
@@ -39,19 +42,163 @@ func TestNewGeneralMetadataFromSubAddress(t *testing.T) {
 func TestNewGeneralMetadataWithFromToSubaddresses(t *testing.T) {
 	subAddress1, _ := libratypes.MakeSubAddress("8f8b82153010a1bd")
 	subAddress2, _ := libratypes.MakeSubAddress("111111153010a111")
-	ret := txnmetadata.NewGeneralMetadataWithFromToSubaddresses(subAddress1, subAddress2)
+	ret := txnmetadata.NewGeneralMetadataWithFromToSubAddresses(subAddress1, subAddress2)
 	assert.Equal(t, "01000108111111153010a11101088f8b82153010a1bd00", hex.EncodeToString(ret))
 }
 
-func TestNewNonCustodyToCustodyRefundMetadataFromEvent(t *testing.T) {
-	subAddress, _ := libratypes.MakeSubAddress("8f8b82153010a1bd")
-	bytes := txnmetadata.NewGeneralMetadataFromSubAddress(subAddress)
-	ret, err := txnmetadata.NewNonCustodyToCustodyRefundMetadataFromEvent(&libraclient.Event{
-		Data: libraclient.EventData{
-			Metadata: hex.EncodeToString(bytes),
-		},
-		SequenceNumber: 123,
+func TestFindRefundReferenceEventFromTransaction(t *testing.T) {
+	receiver := librakeys.MustGenKeys()
+
+	t.Run("return nil for given transaction is nil", func(t *testing.T) {
+		ret := txnmetadata.FindRefundReferenceEventFromTransaction(nil, receiver.AccountAddress())
+		assert.Nil(t, ret)
 	})
-	require.NoError(t, err)
-	assert.NotEmpty(t, ret)
+	t.Run("return event that is receivedpayment type and receiver account address", func(t *testing.T) {
+		txn := libraclienttest.TransactionBuilder{}.Events(
+			libraclienttest.EventBuilder{}.
+				Type("unknowntype").
+				Receiver(receiver.AccountAddress().Hex()),
+			libraclienttest.EventBuilder{}.
+				Type("receivedpayment").
+				Receiver("unknwon address"),
+			libraclienttest.EventBuilder{}.
+				Type("receivedpayment").
+				Receiver(receiver.AccountAddress().Hex()),
+		).Build()
+		ret := txnmetadata.FindRefundReferenceEventFromTransaction(txn, receiver.AccountAddress())
+		require.NotNil(t, ret)
+		assert.Equal(t, "receivedpayment", ret.Data.Type)
+		assert.Equal(t, receiver.AccountAddress().Hex(), ret.Data.Receiver)
+	})
+	t.Run("return nil event if not found", func(t *testing.T) {
+		txn := libraclienttest.TransactionBuilder{}.Events(
+			libraclienttest.EventBuilder{}.
+				Type("unknowntype").
+				Receiver(receiver.AccountAddress().Hex()),
+			libraclienttest.EventBuilder{}.
+				Type("receivedpayment").
+				Receiver("unknwon address"),
+		).Build()
+		ret := txnmetadata.FindRefundReferenceEventFromTransaction(txn, receiver.AccountAddress())
+		require.Nil(t, ret)
+	})
+}
+
+func TestNewRefundMetadataFromEvent(t *testing.T) {
+	referencedEventSeqNum := uint64(123)
+
+	cases := []struct {
+		name             string
+		event            *libraclienttest.EventBuilder
+		expectedErrorMsg string
+		expected         *libratypes.Metadata__GeneralMetadata
+	}{
+		{
+			name: "return event metadata with referenced event: include both from & to subaddress",
+			event: libraclienttest.EventBuilder{}.
+				Metadata(
+					hex.EncodeToString(txnmetadata.NewGeneralMetadataWithFromToSubAddresses(
+						libratypes.SubAddress{1, 2, 3, 4, 5, 6, 7, 8},
+						libratypes.SubAddress{8, 7, 6, 5, 4, 3, 2, 1},
+					))).
+				SequenceNumber(referencedEventSeqNum),
+			expected: &libratypes.Metadata__GeneralMetadata{
+				Value: &libratypes.GeneralMetadata__GeneralMetadataVersion0{
+					Value: libratypes.GeneralMetadataV0{
+						FromSubaddress:  &[]byte{8, 7, 6, 5, 4, 3, 2, 1},
+						ToSubaddress:    &[]byte{1, 2, 3, 4, 5, 6, 7, 8},
+						ReferencedEvent: &referencedEventSeqNum,
+					},
+				},
+			},
+		},
+		{
+			name: "return event metadata with referenced event: only has to subaddress",
+			event: libraclienttest.EventBuilder{}.
+				Metadata(
+					hex.EncodeToString(txnmetadata.NewGeneralMetadataFromSubAddress(
+						libratypes.SubAddress{1, 2, 3, 4, 5, 6, 7, 8},
+					))).
+				SequenceNumber(referencedEventSeqNum),
+			expected: &libratypes.Metadata__GeneralMetadata{
+				Value: &libratypes.GeneralMetadata__GeneralMetadataVersion0{
+					Value: libratypes.GeneralMetadataV0{
+						ToSubaddress:    &[]byte{1, 2, 3, 4, 5, 6, 7, 8},
+						ReferencedEvent: &referencedEventSeqNum,
+					},
+				},
+			},
+		},
+		{
+			name: "return event metadata with referenced event: only has from subaddress",
+			event: libraclienttest.EventBuilder{}.
+				Metadata(
+					hex.EncodeToString(txnmetadata.NewGeneralMetadataToSubAddress(
+						libratypes.SubAddress{1, 2, 3, 4, 5, 6, 7, 8},
+					))).
+				SequenceNumber(referencedEventSeqNum),
+			expected: &libratypes.Metadata__GeneralMetadata{
+				Value: &libratypes.GeneralMetadata__GeneralMetadataVersion0{
+					Value: libratypes.GeneralMetadataV0{
+						FromSubaddress:  &[]byte{1, 2, 3, 4, 5, 6, 7, 8},
+						ReferencedEvent: &referencedEventSeqNum,
+					},
+				},
+			},
+		},
+		{
+			name:             "event is nil",
+			event:            nil,
+			expectedErrorMsg: "must provide refund reference event",
+		},
+		{
+			name:             "event metadata is not hex-encoded string",
+			event:            libraclienttest.EventBuilder{}.Metadata("lj;lafda"),
+			expectedErrorMsg: "decode event metadata failed: encoding/hex: invalid byte: U+006C 'l'",
+		},
+		{
+			name:             "event metadata is not valid LCS bytes",
+			event:            libraclienttest.EventBuilder{}.Metadata("1112233333"),
+			expectedErrorMsg: "can't deserialize metadata: Unknown variant index for Metadata: 17",
+		},
+		{
+			name: "return nil without error if event metadata is empty",
+			event: libraclienttest.EventBuilder{}.
+				Metadata("").
+				SequenceNumber(referencedEventSeqNum),
+			expected: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var event *libraclient.Event
+			if tc.event != nil {
+				event = tc.event.Build()
+			}
+			ret, err := newRefundMetadataFromEvent(event)
+			if tc.expectedErrorMsg != "" {
+				assert.EqualError(t, err, tc.expectedErrorMsg)
+			} else if tc.expected != nil {
+				require.NoError(t, err)
+				ret, err := libratypes.DeserializeMetadata(lcs.NewDeserializer(ret))
+				require.NoError(t, err)
+				assert.EqualValues(t, tc.expected, ret)
+			} else {
+				assert.Nil(t, ret)
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func newRefundMetadataFromEvent(event *libraclient.Event) ([]byte, error) {
+	md, err := txnmetadata.DeserializeMetadata(event)
+	if err != nil {
+		return nil, err
+	}
+	if md == nil {
+		return nil, nil
+	}
+	return txnmetadata.NewRefundMetadataFromEventMetadata(event.SequenceNumber,
+		md.(*libratypes.Metadata__GeneralMetadata))
 }


### PR DESCRIPTION
Split creating refund metadata from event into 2 util funcs:
1. DeserializeMetadata, this one deserialize metadata for user to check metadata type and decide what's next step
2. NewRefundMetadataFromEventMetadata with *libratypes.Metadata__GeneralMetadata type as parameter, this ensures no mistake of passing in other metadata types that we can't handle and need return errors. User should check type and handle different type metadata type properly.
3. Updated refund example to show how to use API, and case analysis when refund a transaction